### PR TITLE
Primary Key Queries

### DIFF
--- a/natural_query/apps.py
+++ b/natural_query/apps.py
@@ -4,7 +4,8 @@ from django.apps import AppConfig, apps
 import itertools
 from django.db.models import DateField, DateTimeField
 from natural_query.fields import NaturalQueryField
-from natural_query.query import NaturalQueryDescriptor, DateNaturalQueryDescriptor, DateTimeNaturalQueryDescriptor
+from natural_query.query import NaturalQueryDescriptor, DateNaturalQueryDescriptor, DateTimeNaturalQueryDescriptor, \
+    PrimaryKeyNaturalQueryDescriptor
 
 
 class NaturalQueryConfig(AppConfig):
@@ -18,6 +19,9 @@ class NaturalQueryConfig(AppConfig):
         models = itertools.chain.from_iterable(app_config.get_models() for app_config in app_configs)
 
         for model in models:
+            if not isinstance(model.pk, PrimaryKeyNaturalQueryDescriptor):
+                model.pk = PrimaryKeyNaturalQueryDescriptor()
+
             non_natural_fields = [field for field in model._meta.fields if
                                   not isinstance(field, NaturalQueryField)]
 

--- a/natural_query/models.py
+++ b/natural_query/models.py
@@ -1,0 +1,9 @@
+from django.db.models import Model
+from natural_query.query import PrimaryKeyNaturalQueryDescriptor
+
+
+class NaturalQueryModel(Model):
+    class Meta:
+        abstract = True
+
+    pk = PrimaryKeyNaturalQueryDescriptor()

--- a/natural_query/query.py
+++ b/natural_query/query.py
@@ -119,6 +119,20 @@ class NaturalQueryDescriptor(NaturalQueryDescriptorBase):
         return self._transform_operator_to_query_object('range', (low, high))
 
 
+class PrimaryKeyNaturalQueryDescriptor(NaturalQueryDescriptor):
+    def __init__(self):
+        super(PrimaryKeyNaturalQueryDescriptor, self).__init__('pk')
+
+    def __get__(self, instance, owner):
+        if not instance:
+            return self
+
+        return instance._get_pk_val()
+
+    def __set__(self, instance, value):
+        return instance._set_pk_val(value)
+
+
 class DatePartNaturalQueryDescriptor(NaturalQueryDescriptorBase):
     def __init__(self, name, date_part):
         super(DatePartNaturalQueryDescriptor, self).__init__(name)

--- a/tests/common/support/models.py
+++ b/tests/common/support/models.py
@@ -4,7 +4,7 @@ from django.db.models import Model, IntegerField, DateTimeField
 
 
 class TestModel(Model):
-    foo = IntegerField()
+    foo = IntegerField(null=True)
     bar = IntegerField(default=1)
     created_at = DateTimeField(auto_now=True)
 

--- a/tests/functional/test_pk_queries.py
+++ b/tests/functional/test_pk_queries.py
@@ -19,6 +19,12 @@ class PrimaryKeyQueriesTestCase(TransactionTestCase):
 
         self.assertEqual(actual, expected)
 
+    def test_pk_is_1_when_fetching_a_record_with_pk_that_is_equal_to_1(self):
+        expected = 1
+        actual = TestModel.objects.get(TestModel.pk == 1).pk
+
+        self.assertEqual(actual, expected)
+
     def test_can_fetch_records_greater_than_1(self):
         expected = TestModel.objects.filter(pk__gt=1)
         actual = TestModel.objects.filter(TestModel.pk > 1)

--- a/tests/functional/test_pk_queries.py
+++ b/tests/functional/test_pk_queries.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from django.db.models import F, Q
+from django.test import TransactionTestCase
+
+from tests.common.support.models import TestModel
+
+
+class PrimaryKeyQueriesTestCase(TransactionTestCase):
+    def setUp(self):
+        TestModel.objects.create(id=1)
+        TestModel.objects.create(id=2)
+        TestModel.objects.create(id=3)
+        TestModel.objects.create(id=4)
+
+    def test_can_fetch_a_record_equal_to_1(self):
+        expected = TestModel.objects.get(pk=1)
+        actual = TestModel.objects.get(TestModel.pk == 1)
+
+        self.assertEqual(actual, expected)
+
+    def test_can_fetch_records_greater_than_1(self):
+        expected = TestModel.objects.filter(pk__gt=1)
+        actual = TestModel.objects.filter(TestModel.pk > 1)
+
+        self.assertEqual(list(actual), list(expected))
+
+    def test_can_fetch_records_lower_than_2(self):
+        expected = TestModel.objects.filter(pk__lt=2)
+        actual = TestModel.objects.filter(TestModel.pk < 2)
+
+        self.assertEqual(list(actual), list(expected))
+
+    def test_can_fetch_records_greater_or_equal_to_bar_plus_one(self):
+        expected = TestModel.objects.filter(pk__gte=F('bar') + 1)
+        actual = TestModel.objects.filter(TestModel.pk >= TestModel.bar + 1)
+
+        self.assertEqual(list(actual), list(expected))
+
+    def test_can_fetch_records_with_pk_greater_than_one_and_bar_equal_to_one(self):
+        expected = TestModel.objects.filter(pk__gt=1, bar=1)
+        actual = TestModel.objects.filter((TestModel.pk > 1) & (TestModel.bar == 1))
+
+        self.assertEqual(list(actual), list(expected))
+
+    def test_can_fetch_records_with_pk_greater_than_one_or_bar_equal_to_one(self):
+        expected = TestModel.objects.filter(Q(pk__gt=1) | Q(bar=1))
+        actual = TestModel.objects.filter((TestModel.pk > 1) | (TestModel.bar == 1))
+
+        self.assertEqual(list(actual), list(expected))

--- a/tests/unit/test_natural_query_field.py
+++ b/tests/unit/test_natural_query_field.py
@@ -16,8 +16,8 @@ class NaturalQueryFieldTestCase(SimpleTestCase):
             self.fail('TestModel has no attribute named foo')
 
     def test_a_query_descriptor_is_not_added_to_the_model_when_a_class_attribute_already_exists(self):
-        sut = NaturalQueryField(name='pk')
+        sut = NaturalQueryField(name='clean')
 
-        sut.contribute_to_class(TestModel, 'pk')
+        sut.contribute_to_class(TestModel, 'clean')
 
-        self.assertNotIsInstance(TestModel.pk, NaturalQueryDescriptor)
+        self.assertNotIsInstance(TestModel.clean, NaturalQueryDescriptor)

--- a/tests/unit/test_primary_key_natural_field_descriptor.py
+++ b/tests/unit/test_primary_key_natural_field_descriptor.py
@@ -1,0 +1,29 @@
+from django.test import SimpleTestCase
+from mock import sentinel, patch
+
+from natural_query.query import PrimaryKeyNaturalQueryDescriptor
+from tests.common.support.models import TestModel
+
+
+class NaturalQueryFieldTestCase(SimpleTestCase):
+    def test_can_access_query_descriptor_from_model_type(self):
+        self.assertIsInstance(TestModel.pk, PrimaryKeyNaturalQueryDescriptor)
+
+    def test_can_access_primary_key_from_model_instance(self):
+        sut = TestModel()
+
+        with patch.object(TestModel, '_get_pk_val') as mocked_get_pk_val:
+            _ = sut.pk
+
+        mocked_get_pk_val.assert_called_once_with()
+
+    def test_cant_set_query_descriptor_from_model_type(self):
+        with self.assertRaisesMessage(TypeError, 'Cannot set query descriptor.'):
+            TestModel.pk = sentinel.PK
+
+    def test_can_set_pk_from_model_instance(self):
+        with patch.object(TestModel, '_set_pk_val') as mocked_set_pk_val:
+            sut = TestModel()
+            sut.pk = sentinel.PK
+
+        mocked_set_pk_val.assert_called_once_with(sentinel.PK)

--- a/tests/unit/test_primary_key_natural_field_descriptor.py
+++ b/tests/unit/test_primary_key_natural_field_descriptor.py
@@ -17,10 +17,6 @@ class NaturalQueryFieldTestCase(SimpleTestCase):
 
         mocked_get_pk_val.assert_called_once_with()
 
-    def test_cant_set_query_descriptor_from_model_type(self):
-        with self.assertRaisesMessage(TypeError, 'Cannot set query descriptor.'):
-            TestModel.pk = sentinel.PK
-
     def test_can_set_pk_from_model_instance(self):
         with patch.object(TestModel, '_set_pk_val') as mocked_set_pk_val:
             sut = TestModel()


### PR DESCRIPTION
This PR enables us to use the following syntax:

``` python
MyModel.objects.get(MyModel.pk == 1)
```
